### PR TITLE
[메인페이지] 리팩토링, 레이아웃 일부 변경

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -42,27 +42,27 @@ function Home() {
 	return (
 		<div className="mainPage bg-black w-screen overflow-hidden">
 			<MainBanner></MainBanner>
-			<section className="popular">
-				<h3 className={S.popularTitle}>타잉 인기 영화</h3>
+			<section className="mainSwiper popular">
+				<h3 className={S.popularTitle}>인기 영화</h3>
 				{contents?.map(
 					(contentCategory) =>
 						contentCategory.title === "영화" && (
 							<Swiper
 								key={contentCategory.title}
-								slidesPerView={7}
+								slidesPerView={5.5}
 								breakpoints={{
 									480: {
-										slidesPerView: 5,
+										slidesPerView: 3,
 									},
 									768: {
-										slidesPerView: 6,
+										slidesPerView: 4,
 									},
 									1024: {
-										slidesPerView: 7,
+										slidesPerView: 5,
 									},
 								}}
 								slidesPerGroup={3}
-								spaceBetween={10}
+								spaceBetween={70}
 								navigation={{
 									nextEl: "#popularNextButton",
 									prevEl: "#popularPrevButton",
@@ -72,16 +72,21 @@ function Home() {
 								pagination={{ clickable: true }}
 								modules={[Navigation, Pagination]}
 								tabIndex={0}
-								className="overflow-y-visible mb-10 px-10"
+								className="overflow-y-visible mb-10 pl-[5%]"
 							>
-								{contentCategory.data.slice(27, 38).map((item) => (
-									<SwiperSlide key={item.id}>
-										<Link to={`contents/${item.id}`}>
+								{contentCategory.data.slice(27, 37).map((item, index) => (
+									<SwiperSlide key={item.id} className={S.listContent}>
+										<span className="rank absolute bottom-[0%] left-[-20%] text-[7rem] leading-[6rem] text-white italic font-extrabold">
+											{index + 1}
+										</span>
+										<Link
+											to={`contents/${item.id}`}
+											className="w-full flex flex-row items-end gap-[4%]"
+										>
 											<img
 												src={getPbImageURL(item, "poster")}
 												alt={item.title}
 											/>
-											<p className="text-gray200 text-xl mt-2">{item.title}</p>
 										</Link>
 									</SwiperSlide>
 								))}
@@ -107,27 +112,27 @@ function Home() {
 						)
 				)}
 			</section>
-			<section className="popular">
-				<h3 className={S.popularTitle}>타잉 인기 드라마</h3>
+			<section className="mainSwiper popular">
+				<h3 className={S.popularTitle}>인기 TV프로그램</h3>
 				{contents?.map(
 					(contentCategory) =>
 						contentCategory.title === "TV 프로그램" && (
 							<Swiper
 								key={contentCategory.title}
-								slidesPerView={7}
+								slidesPerView={5.5}
 								breakpoints={{
 									480: {
-										slidesPerView: 5,
+										slidesPerView: 3,
 									},
 									768: {
-										slidesPerView: 6,
+										slidesPerView: 4,
 									},
 									1024: {
-										slidesPerView: 7,
+										slidesPerView: 5,
 									},
 								}}
 								slidesPerGroup={3}
-								spaceBetween={10}
+								spaceBetween={70}
 								navigation={{
 									nextEl: "#popularTvNextButton",
 									prevEl: "#popularTvPrevButton",
@@ -137,16 +142,18 @@ function Home() {
 								pagination={{ clickable: true }}
 								modules={[Navigation, Pagination]}
 								tabIndex={0}
-								className="overflow-y-visible mb-10 px-10"
+								className="overflow-y-visible mb-10 pl-[5%]"
 							>
-								{contentCategory.data.slice(27, 38).map((item) => (
-									<SwiperSlide key={item.id}>
-										<Link to={`contents/${item.id}`}>
+								{contentCategory.data.slice(27, 37).map((item, index) => (
+									<SwiperSlide key={item.id} className={S.listContent}>
+										<span className="rank absolute bottom-[0%] left-[-20%] text-[7rem] leading-[6rem] text-white italic font-extrabold">
+											{index + 1}
+										</span>
+										<Link to={`contents/${item.id}`} className="w-full">
 											<img
 												src={getPbImageURL(item, "poster")}
 												alt={item.title}
 											/>
-											<p className="text-gray200 text-xl mt-2">{item.title}</p>
 										</Link>
 									</SwiperSlide>
 								))}
@@ -174,17 +181,39 @@ function Home() {
 			</section>
 			<MainList
 				classTitle={"romance"}
-				listTitle="사랑에 빠지는 순간, 로맨스 영화"
+				listTitle={"사랑에 빠지는 순간, 로맨스"}
+				genre={"영화"}
 				genreId={"n0ztxfbdj977ycx"}
-				startNum={0}
-				endNum={10}
+			/>
+			<MainList
+				classTitle={"kids"}
+				listTitle={"아이들과 함께! 키즈 프로그램"}
+				genre={"TV 프로그램"}
+				genreId={"jbrgnkddukg6sod"}
+			/>
+			<MainList
+				classTitle={"tv"}
+				listTitle={"가족끼리 즐기자! 예능 프로그램"}
+				genre={"TV 프로그램"}
+				genreId={"bk1642512y8h7u4"}
+			/>
+			<MainList
+				classTitle={"sf"}
+				listTitle={"강력한 비주얼 ! SF 영화"}
+				genre={"영화"}
+				genreId={"i1cbm8l1n1opqh1"}
 			/>
 			<MainList
 				classTitle={"horror"}
-				listTitle={"불 끄면 생각날걸 ? 공포영화"}
+				listTitle={"불 끄면 생각날걸? 공포 영화"}
+				genre={"영화"}
 				genreId={"cpcr28a1nvppyow"}
-				startNum={0}
-				endNum={10}
+			/>
+			<MainList
+				classTitle={"documentary"}
+				listTitle={"다큐멘터리"}
+				genre={"TV 프로그램"}
+				genreId={"rpq7aiz0y08y0y8"}
 			/>
 		</div>
 	);

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -4,13 +4,21 @@
 }
 
 .mainBannerMoreBtn {
-  @apply absolute px-[2.7%] py-5 bottom-[17%] right-[5%] border border-white rounded bg-transparent saturate-100 backdrop-blur-3xl z-10;
+  @apply absolute px-[2.7%] py-5 bottom-[17%] right-[5%] border border-gray-300 rounded bg-transparent saturate-100 backdrop-blur-3xl z-10 hover:border-white;
   @apply text-gray-200 text-xl font-light;
+}
+
+.listContent {
+  @apply text-gray200 hover:-translate-y-2 duration-300 hover:text-white;
+}
+
+.listName {
+  @apply text-xl mt-2 whitespace-nowrap overflow-hidden text-ellipsis;
 }
 
 .listTitle,
 .popularTitle {
-  @apply text-white text-2xl font-semibold ml-10 mb-3;
+  @apply text-white text-2xl font-semibold ml-10 mb-4;
 }
 
 .mainButtonPrev,

--- a/src/pages/MainList.jsx
+++ b/src/pages/MainList.jsx
@@ -7,11 +7,10 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination } from "swiper/modules";
 import PropTypes from "prop-types";
 
-export function MainList({ classTitle, listTitle, genreId, startNum, endNum }) {
+export function MainList({ classTitle, listTitle, genre, genreId }) {
 	const [contents, setContents] = useState([]);
 	const [status, setStatus] = useState("pending");
 	const [error, setError] = useState(null);
-	const itemCount = 20;
 
 	useEffect(() => {
 		setStatus("loading");
@@ -34,11 +33,11 @@ export function MainList({ classTitle, listTitle, genreId, startNum, endNum }) {
 	}, []);
 
 	return (
-		<section className={classTitle}>
+		<section className={`${classTitle} mainSwiper`}>
 			<h3 className={`${classTitle}List ${S.listTitle}`}>{listTitle}</h3>
 			{contents?.map(
 				(contentCategory) =>
-					contentCategory.title === "영화" && (
+					contentCategory.title === `${genre}` && (
 						<Swiper
 							key={contentCategory.title}
 							slidesPerView={7}
@@ -53,7 +52,7 @@ export function MainList({ classTitle, listTitle, genreId, startNum, endNum }) {
 									slidesPerView: 7,
 								},
 							}}
-							slidesPerGroup={3}
+							slidesPerGroup={7}
 							spaceBetween={10}
 							navigation={{
 								nextEl: "#mainNextButton",
@@ -69,13 +68,13 @@ export function MainList({ classTitle, listTitle, genreId, startNum, endNum }) {
 							{contentCategory.data
 								.filter((movie) => movie.genre === genreId)
 								.map((item) => (
-									<SwiperSlide key={item.id}>
+									<SwiperSlide key={item.id} className={S.listContent}>
 										<Link to={`contents/${item.id}`}>
 											<img
 												src={getPbImageURL(item, "poster")}
 												alt={item.title}
 											/>
-											<p className="text-gray200 text-xl mt-2">{item.title}</p>
+											<p className={S.listName}>{item.title}</p>
 										</Link>
 									</SwiperSlide>
 								))}
@@ -107,7 +106,6 @@ export function MainList({ classTitle, listTitle, genreId, startNum, endNum }) {
 MainList.propTypes = {
 	classTitle: PropTypes.string.isRequired,
 	listTitle: PropTypes.string.isRequired,
+	genre: PropTypes.string.isRequired,
 	genreId: PropTypes.string.isRequired,
-	startNum: PropTypes.number.isRequired,
-	endNum: PropTypes.number.isRequired,
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -83,9 +83,14 @@ html {
 .mainPage .swiper-button-prev,
 .mainPage .swiper-button-next {
   top: 0;
-  height: 100%;
+  height: 110%;
   color: white;
   opacity: 0.6;
+}
+
+.popular .swiper-button-prev,
+.popular .swiper-button-next {
+  top: 5.8%;
 }
 
 .mainPage .swiper-button-prev {
@@ -116,21 +121,29 @@ html {
 
 .mainPage .swiper-button-prev {
   left: 0;
+  width: 3%;
 }
 
 .mainPage .swiper-button-next {
   right: 0;
+  width: 3%;
 }
 
-.popular .swiper-pagination {
+.mainSwiper {
+  margin-bottom: 4%;
+  padding-left: 5%;
+  padding-right: 5%;
+}
+
+.mainSwiper .swiper-pagination {
   position: absolute;
   width: 10% !important;
   height: 5%;
-  left: 91% !important;
-  top: -8% !important;
+  left: 93% !important;
+  top: -8.5% !important;
 }
 
-.popular .swiper-pagination .swiper-pagination-bullet {
+.mainSwiper .swiper-pagination .swiper-pagination-bullet {
   width: 0.5rem;
   height: 0.5rem;
   background: white;


### PR DESCRIPTION
### 📝 Description

컴포넌트를 일부 분리, 더 효과적인 레이아웃 완성

### 💽 Commits

1. 메인 배너와 각 제목별 리스트들 컴포넌트 분리
2. 인기 프로그램과 인기 영화 디자인 수정
3. 양쪽 간격을 주어 답답해보이는 레이아웃 수정

### 🖼 Result

![screencapture-localhost-5173-react-project-7-2023-09-18-17_55_07 (1)](https://github.com/FRONTENDSCHOOL6/react-project-7/assets/116864776/58f9ee32-1252-4197-aa24-7ce2a2bd999d)

