### PR TITLE
[Header] 프로필 이미지 비율 유지

### DIFF
--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -25,5 +25,5 @@
 
 .profileImg {
   @apply h-full w-full object-cover;
-  @apply max-md:w-4/5;
+  @apply max-md:w-4/5 cursor-pointer;
 }

--- a/src/components/header/Header.module.css
+++ b/src/components/header/Header.module.css
@@ -24,6 +24,6 @@
 }
 
 .profileImg {
-  @apply h-full w-full;
+  @apply h-full w-full object-cover;
   @apply max-md:w-4/5;
 }

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -124,7 +124,7 @@ function Header() {
 				<li
 					onMouseEnter={() => setIsImgHovered(true)}
 					onMouseLeave={() => setIsImgHovered(false)}
-					className="h-full"
+					className="h-[2.813rem] w-[2.813rem]"
 				>
 					<img
 						src={profileImg ? profileImg : profileIcon}
@@ -142,7 +142,7 @@ function Header() {
 			>
 				<div className="flex flex-col px-5">
 					<div className="flex gap-3 items-center">
-						<div className="w-10 h-10 object-cover">
+						<div className="w-10 h-10">
 							<img
 								src={profileImg ? profileImg : profileIcon}
 								alt="프로필"


### PR DESCRIPTION
### 📝 Description

프로필 이미지 비율을 유지하도록 수정

### 💽 Commits

1:1 비율이 아닌 이미지가 들어왔을 때도 이미지가 잘리지만 1:1 비율로 보이도록 수정

### 🖼 Result
<img width="190" alt="image" src="https://github.com/FRONTENDSCHOOL6/react-project-7/assets/116864776/71340588-5163-4793-a44a-6132d789180c">